### PR TITLE
Live Push: Hotfix to get all tags of the repository November 19, 2020

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v2-beta
       - uses: justia/ga-releaser@master
         env:

--- a/examples/release_on_develop_branch.yml
+++ b/examples/release_on_develop_branch.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v2-beta
       - uses: justia/ga-releaser@master
         env:

--- a/examples/release_on_develop_branch_calver_monthly.yml
+++ b/examples/release_on_develop_branch_calver_monthly.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: develop
+          fetch-depth: 0
       - uses: actions/setup-node@v2-beta
       - uses: justia/ga-releaser@master
         env:

--- a/examples/release_on_master_branch.yml
+++ b/examples/release_on_master_branch.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v2-beta
       - uses: justia/ga-releaser@master
         env:


### PR DESCRIPTION
## General

This is a hotfix to get all tags from the repository in the GitHub action

### Bug Fixes

- Hotfix to get the missing tags reference (d213df54fad20e110f3540b74dcddc10acb90f6d)


