### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# [1.0.0](https://github.com/justia/ga-releaser/compare/0.2.1...1.0.0) (2020-11-19)
+
 ## [0.2.1](https://github.com/justia/ga-releaser/compare/0.2.0...0.2.1) (2020-11-19)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@justia/release",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justia/release",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "A script to generate releases and changelog",
   "main": "src/index.js",
   "scripts": {},


### PR DESCRIPTION
# [1.0.0](https://github.com/justia/ga-releaser/compare/0.2.1...1.0.0) (2020-11-19)