### PR TITLE
Live Push: GitHub action uses the release branch November 19, 2020

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v2-beta
-      - uses: justia/ga-releaser@master
+      - uses: justia/ga-releaser@release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/examples/release_on_develop_branch.yml
+++ b/examples/release_on_develop_branch.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v2-beta
-      - uses: justia/ga-releaser@master
+      - uses: justia/ga-releaser@release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/examples/release_on_develop_branch_calver_monthly.yml
+++ b/examples/release_on_develop_branch_calver_monthly.yml
@@ -13,7 +13,7 @@ jobs:
           ref: develop
           fetch-depth: 0
       - uses: actions/setup-node@v2-beta
-      - uses: justia/ga-releaser@master
+      - uses: justia/ga-releaser@release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/examples/release_on_master_branch.yml
+++ b/examples/release_on_master_branch.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v2-beta
-      - uses: justia/ga-releaser@master
+      - uses: justia/ga-releaser@release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## General

### Bug Fixes

- Github action uses the release branch (e6823ab5923fa53019fd64fce8d34234d36800b4)


