### PR TITLE
Release Push 2021-01-29

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,6 @@ jobs:
       - uses: justia/ga-releaser@release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASER_BYPASS_PR_TOKEN: ${{ secrets.RELEASER_BYPASS_PR_TOKEN }}
         with:
           head-branch: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.3.0](https://github.com/justia/ga-releaser/compare/1.2.0...1.3.0) (2021-01-29)
+
+
+### Features
+
+* update @justia/releaser package with all improvements ([11dcb20](https://github.com/justia/ga-releaser/commit/11dcb209fe165f570a439ebccce12a5b03ba2efc))
+
 # [1.2.0](https://github.com/justia/ga-releaser/compare/1.1.0...1.2.0) (2020-12-31)
 
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ jobs:
       - uses: justia/ga-releaser@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASER_BYPASS_PR_TOKEN: ${{ secrets.RELEASER_BYPASS_PR_TOKEN }}
 ```
 
 You can check the file `action.yml` to know what input values has the github action.
@@ -40,6 +41,7 @@ jobs:
       - uses: justia/ga-releaser@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASER_BYPASS_PR_TOKEN: ${{ secrets.RELEASER_BYPASS_PR_TOKEN }}
         with:
           versioning-specification: 'calver'
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 GA-Releaser is an implementation of the project [release-it](https://github.com/release-it/release-it) with Github Actions to the Justia projects.
 
 ## How can I configure any repository?
+It's important to call `release.yml` the GitHub Action to make compatible with the command jReleaser on the computers.
+
+An example can be:
 ```yaml
 name: Release
 on:
@@ -45,4 +48,29 @@ jobs:
         with:
           versioning-specification: 'calver'
 ```
-And you can set the format of calver with the input `calver-format`, the default value is `YYYY.MM.MICRO`.
+And you can set the format of calver with the input `calver-format`, the default value is `YYYY.MINOR.MICRO`.
+
+
+# Available options
+
+|          Property          |                                                                      Description                                                                      |           Default          | Is required? |
+|:--------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------:|:--------------------------:|:------------:|
+|        `git-message`       |                                                                 Commit message to use                                                                 | chore(release): ${version} |       ❌      |
+|      `github-release`      |                                                      Don't publish a github release if set false                                                      |            true            |       ❌      |
+|       `release-name`       |                                                                  GitHub Release title                                                                 |     Release ${version}     |       ❌      |
+|        `npm-publish`       |                                                                      NPM Publish                                                                      |            false           |       ❌      |
+|          `preset`          |                                                     The preset from Conventional Changelog to use                                                     |           angular          |       ❌      |
+| `versioning-specification` |                                                Versioning specification to use. Options: semver, calver                                               |           semver           |       ❌      |
+|       `calver-format`      | Format of calver. More info: [https://www.npmjs.com/package/calver#available-format-tags](https://www.npmjs.com/package/calver#available-format-tags) |      YYYY.MINOR.MICRO      |       ❌      |
+|        `output-file`       |                                                            File to output the changelog to                                                            |        CHANGELOG.md        |       ❌      |
+|      `require-commits`     |                                             Do nothing when the changelog from the latest release is empty                                            |            true            |       ❌      |
+|     `require-upstream`     |                                                        Requires upstream to push the changelog                                                        |            false           |       ❌      |
+|       `git-user-name`      |                                                        The git user.name to use for the commit                                                        |                            |       ❌      |
+|      `git-user-email`      |                                                        The git user.email to use for the commit                                                       |                            |       ❌      |
+|     `fallback-version`     |                                               The fallback version if a previous version doesn't exists                                               |            0.0.0           |       ❌      |
+|        `base-branch`       |                                                             The base branch of repository                                                             |           master           |       ❌      |
+|        `head-branch`       |                                                             The head branch of repository                                                             |           develop          |       ❌      |
+|          `use-pr`          |                                                          Create a pull request for the change                                                         |            true            |       ❌      |
+|       `automerge-pr`       |                                                           Automerge the pull request created                                                          |            true            |       ❌      |
+|    `use-version-branch`    |                                                                 Use a versioned branch                                                                |            true            |       ❌      |
+|   `remove-version-branch`  |                                                 Remove version branch when the pull request is merged                                                 |            true            |       ❌      |

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
 
   calver-format:
     description: 'Format of calver. More info: https://www.npmjs.com/package/calver#available-format-tags'
-    default: 'YYYY.MM.MICRO'
+    default: 'YYYY.MINOR.MICRO'
     required: false
 
   output-file:

--- a/examples/release_on_develop_branch.yml
+++ b/examples/release_on_develop_branch.yml
@@ -20,5 +20,6 @@ jobs:
       - uses: justia/ga-releaser@release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASER_BYPASS_PR_TOKEN: ${{ secrets.RELEASER_BYPASS_PR_TOKEN }}
         with:
           use-version-branch: false

--- a/examples/release_on_develop_branch_calver_monthly.yml
+++ b/examples/release_on_develop_branch_calver_monthly.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: justia/ga-releaser@release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASER_BYPASS_PR_TOKEN: ${{ secrets.RELEASER_BYPASS_PR_TOKEN }}
         with:
           versioning-specification: calver
           use-version-branch: false

--- a/examples/release_on_master_branch.yml
+++ b/examples/release_on_master_branch.yml
@@ -20,5 +20,6 @@ jobs:
       - uses: justia/ga-releaser@release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASER_BYPASS_PR_TOKEN: ${{ secrets.RELEASER_BYPASS_PR_TOKEN }}
         with:
           head-branch: master

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,16 +70,17 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@justia/releaser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@justia/releaser/-/releaser-1.2.0.tgz",
-      "integrity": "sha512-DZ8soohwRDQp5AUtDXgcqa5a9MCAo+7+XVL2RHwDIKC49nQKZEhXevTRvHFDmYd4zTmG4MvuJVF7C0f26LS8Cw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@justia/releaser/-/releaser-1.3.2.tgz",
+      "integrity": "sha512-6lE/GGv7UPcsBnSipttlw6q8BzVPJLuX96+BHlPZomJecI3mpH/sumb8eo09fAc2Peq7P0FOJwPFjTUKESoM/g==",
       "requires": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.4",
         "@actions/github": "^4.0.0",
         "@octokit/plugin-rest-endpoint-methods": "^4.2.1",
         "@release-it/conventional-changelog": "^2.0.0",
-        "calver": "^20.5.3",
+        "calver": "^21.1.0",
+        "conventional-recommended-bump": "^6.1.0",
         "release-it": "^14.2.0",
         "yaml": "^1.10.0"
       }
@@ -108,17 +109,17 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.4.tgz",
-      "integrity": "sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
       "requires": {
-        "@octokit/types": "^6.0.0"
+        "@octokit/types": "^6.0.3"
       }
     },
     "@octokit/core": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.4.tgz",
-      "integrity": "sha512-d9dTsqdePBqOn7aGkyRFe7pQpCXdibSJ5SFnrTr0axevObZrpz3qkWm7t/NjYv5a66z6vhfteriaq4FRz3e0Qg==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.5.tgz",
+      "integrity": "sha512-+DCtPykGnvXKWWQI0E1XD+CCeWSBhB6kwItXqfFmNBlIlhczuDPbg+P6BtLnVBaRJDAjv+1mrUJuRsFSjktopg==",
       "requires": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -129,56 +130,56 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.10.tgz",
-      "integrity": "sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
       "requires": {
-        "@octokit/types": "^6.0.0",
+        "@octokit/types": "^6.0.3",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.8.tgz",
-      "integrity": "sha512-WnCtNXWOrupfPJgXe+vSmprZJUr0VIu14G58PMlkWGj3cH+KLZEfKMmbUQ6C3Wwx6fdhzVW1CD5RTnBdUHxhhA==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.9.tgz",
+      "integrity": "sha512-c+0yofIugUNqo+ktrLaBlWSbjSq/UF8ChAyxQzbD3X74k1vAuyLKdDJmPwVExUFSp6+U1FzWe+3OkeRsIqV0vg==",
       "requires": {
         "@octokit/request": "^5.3.0",
-        "@octokit/types": "^6.0.0",
+        "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/openapi-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-2.0.1.tgz",
-      "integrity": "sha512-9AuC04PUnZrjoLiw3uPtwGh9FE4Q3rTqs51oNlQ0rkwgE8ftYsOC+lsrQyvCvWm85smBbSc0FNRKKumvGyb44Q=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-3.3.0.tgz",
+      "integrity": "sha512-s3dd32gagPmKaSLNJ9aPNok7U+tl69YLESf6DgQz5Ml/iipPZtif3GLvWpNXoA6qspFm1LFUZX+C3SqWX/Y/TQ=="
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.2.tgz",
-      "integrity": "sha512-3Dy7/YZAwdOaRpGQoNHPeT0VU1fYLpIUdPyvR37IyFLgd6XSij4j9V/xN/+eSjF2KKvmfIulEh9LF1tRPjIiDA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.9.0.tgz",
+      "integrity": "sha512-XxbOg45r2n/2QpU6hnGDxQNDRrJ7gjYpMXeDbUCigWTHECmjoyFLizkFO2jMEtidMkfiELn7AF8GBAJ/cbPTnA==",
       "requires": {
-        "@octokit/types": "^6.0.1"
+        "@octokit/types": "^6.6.0"
       }
     },
     "@octokit/plugin-request-log": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
-      "integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.4.1.tgz",
-      "integrity": "sha512-+v5PcvrUcDeFXf8hv1gnNvNLdm4C0+2EiuWt9EatjjUmfriM1pTMM+r4j1lLHxeBQ9bVDmbywb11e3KjuavieA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.9.0.tgz",
+      "integrity": "sha512-EAr2epvY8JfXSi/cdMsyyfBctdKkolDH7xSgu3MKBqPRm0WfQ2QvI050jz61XZXoVK3ZgrhdMCyd1GgOFz7CSw==",
       "requires": {
-        "@octokit/types": "^6.1.0",
+        "@octokit/types": "^6.6.0",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "5.4.12",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.12.tgz",
-      "integrity": "sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==",
+      "version": "5.4.13",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.13.tgz",
+      "integrity": "sha512-WcNRH5XPPtg7i1g9Da5U9dvZ6YbTffw9BN2rVezYiE7couoSyaRsw0e+Tl8uk1fArHE7Dn14U7YqUDy59WaqEw==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
@@ -191,11 +192,11 @@
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.4.tgz",
-      "integrity": "sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
       "requires": {
-        "@octokit/types": "^6.0.0",
+        "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
@@ -231,11 +232,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.1.2.tgz",
-      "integrity": "sha512-LPCpcLbcky7fWfHCTuc7tMiSHFpFlrThJqVdaHgowBTMS0ijlZFfonQC/C1PrZOjD4xRCYgBqH9yttEATGE/nw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.6.0.tgz",
+      "integrity": "sha512-nmFoU3HCbw1AmnZU/eto2VvzV06+N7oAqXwMmAHGlNDF+KFykksh/VlAl85xc1P5T7Mw8fKYvXNaImNHCCH/rg==",
       "requires": {
-        "@octokit/openapi-types": "^2.0.1",
+        "@octokit/openapi-types": "^3.3.0",
         "@types/node": ">= 8"
       }
     },
@@ -293,9 +294,9 @@
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
     },
     "@types/node": {
-      "version": "14.14.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.16.tgz",
-      "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw=="
+      "version": "14.14.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -562,9 +563,9 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "calver": {
-      "version": "20.5.5",
-      "resolved": "https://registry.npmjs.org/calver/-/calver-20.5.5.tgz",
-      "integrity": "sha512-YGKdDZe5ISWMMQVtypkk/KEHriuxxmZx9rOUeUIS5gxi79LqwfCa9a4u94lI1L30H1hoGADE3idaRUIcSMa/9A=="
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/calver/-/calver-21.1.0.tgz",
+      "integrity": "sha512-rz/CBoA7cl7GTJzisUDVq2Gj4RZoh+bGYbTlX133BzwKZIfqCJLHa+1wZqIr1GMaXv6VMbAwJ14YwVnackuBCA=="
     },
     "camelcase": {
       "version": "5.3.1",
@@ -750,16 +751,16 @@
       }
     },
     "conventional-changelog-core": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.1.tgz",
-      "integrity": "sha512-8cH8/DEoD3e5Q6aeogdR5oaaKs0+mG6+f+Om0ZYt3PNv7Zo0sQhu4bMDRsqAF+UTekTAtP1W/C41jH/fkm8Jtw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.2.tgz",
+      "integrity": "sha512-7pDpRUiobQDNkwHyJG7k9f6maPo9tfPzkSWbRq97GGiZqisElhnvUZSvyQH20ogfOjntB5aadvv6NNcKL1sReg==",
       "requires": {
         "add-stream": "^1.0.0",
         "conventional-changelog-writer": "^4.0.18",
         "conventional-commits-parser": "^3.2.0",
         "dateformat": "^3.0.0",
         "get-pkg-repo": "^1.0.0",
-        "git-raw-commits": "2.0.0",
+        "git-raw-commits": "^2.0.8",
         "git-remote-origin-url": "^2.0.0",
         "git-semver-tags": "^4.1.1",
         "lodash": "^4.17.15",
@@ -818,9 +819,9 @@
       "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g=="
     },
     "conventional-changelog-writer": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.18.tgz",
-      "integrity": "sha512-mAQDCKyB9HsE8Ko5cCM1Jn1AWxXPYV0v8dFPabZRkvsiWUul2YyAqbIaoMKF88Zf2ffnOPSvKhboLf3fnjo5/A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
+      "integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
       "requires": {
         "compare-func": "^2.0.0",
         "conventional-commits-filter": "^2.0.7",
@@ -858,15 +859,15 @@
       }
     },
     "conventional-recommended-bump": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.0.11.tgz",
-      "integrity": "sha512-FciYBMwzwwBZ1K4NS8c57rsOfSc51e1V6UVSNIosrjH+A6xXkyiA4ELwoWyRKdMhJ+m3O6ru9ZJ7F2QFjjYJdQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.1.0.tgz",
+      "integrity": "sha512-uiApbSiNGM/kkdL9GTOLAqC4hbptObFo4wW2QRyHsKciGAfQuLU1ShZ1BIVI/+K2BE/W1AWYQMCXAsv4dyKPaw==",
       "requires": {
         "concat-stream": "^2.0.0",
         "conventional-changelog-preset-loader": "^2.3.4",
         "conventional-commits-filter": "^2.0.7",
         "conventional-commits-parser": "^3.2.0",
-        "git-raw-commits": "2.0.0",
+        "git-raw-commits": "^2.0.8",
         "git-semver-tags": "^4.1.1",
         "meow": "^8.0.0",
         "q": "^1.5.1"
@@ -920,12 +921,9 @@
       }
     },
     "dargs": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-      "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg=="
     },
     "dateformat": {
       "version": "3.0.3",
@@ -960,6 +958,11 @@
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "6.0.0",
@@ -1099,9 +1102,9 @@
       }
     },
     "fast-glob": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1112,9 +1115,9 @@
       }
     },
     "fastq": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
-      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
+      "integrity": "sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -1356,147 +1359,24 @@
       }
     },
     "git-raw-commits": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
-      "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.10.tgz",
+      "integrity": "sha512-sHhX5lsbG9SOO6yXdlwgEMQ/ljIn7qMpAbJZCGfXX2fq5T8M5SrDnpYk9/4HswTildcIqatsWa91vty6VhWSaQ==",
       "requires": {
-        "dargs": "^4.0.1",
-        "lodash.template": "^4.0.2",
-        "meow": "^4.0.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0"
+        "dargs": "^7.0.0",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        },
-        "camelcase-keys": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+        "split2": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "readable-stream": "^3.0.0"
           }
-        },
-        "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-        },
-        "map-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
-        },
-        "meow": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-          "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
-          }
-        },
-        "minimist-options": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-          "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-          "requires": {
-            "arrify": "^1.0.1",
-            "is-plain-obj": "^1.1.0"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "quick-lru": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-          "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "redent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-          "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-indent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
         }
       }
     },
@@ -1651,9 +1531,9 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
     },
     "hosted-git-info": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-      "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -2058,32 +1938,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
-    },
-    "lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -2179,9 +2037,9 @@
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
     },
     "meow": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.0.tgz",
-      "integrity": "sha512-fNWkgM1UVMey2kf24yLiccxLihc5W+6zVus3/N0b+VfnJgxV99E9u04X6NAiKdg6ED7DAQBX5sy36NM0QJZkWA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
       "requires": {
         "@types/minimist": "^1.2.0",
         "camelcase-keys": "^6.2.2",
@@ -2382,11 +2240,6 @@
       "requires": {
         "path-key": "^3.0.0"
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -2653,9 +2506,9 @@
       "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
     },
     "parse-json": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-      "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -2664,12 +2517,14 @@
       }
     },
     "parse-path": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.2.tgz",
-      "integrity": "sha512-HSqVz6iuXSiL8C1ku5Gl1Z5cwDd9Wo0q8CoffdAghP6bz8pJa1tcMC+m4N+z6VAS8QdksnIGq1TB6EgR4vPR6w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.3.tgz",
+      "integrity": "sha512-9Cepbp2asKnWTJ9x2kpw6Fe8y9JDbqwahGCTvklzd/cEq5C5JC59x2Xb0Kx+x0QZ8bvNquGO8/BWP0cwBHzSAA==",
       "requires": {
         "is-ssh": "^1.3.0",
-        "protocols": "^1.4.0"
+        "protocols": "^1.4.0",
+        "qs": "^6.9.4",
+        "query-string": "^6.13.8"
       }
     },
     "parse-url": {
@@ -2781,6 +2636,21 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+    },
+    "query-string": {
+      "version": "6.13.8",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
+      "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -3069,6 +2939,17 @@
             "p-limit": "^3.0.2"
           }
         },
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -3258,6 +3139,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
@@ -3303,6 +3189,11 @@
           }
         }
       }
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-width": {
       "version": "4.2.0",
@@ -3464,9 +3355,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.3.tgz",
-      "integrity": "sha512-feZzR+kIcSVuLi3s/0x0b2Tx4Iokwqt+8PJM7yRHKuldg4MLdam4TCFeICv+lgDtuYiCtdmrtIP+uN9LWvDasw==",
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.5.tgz",
+      "integrity": "sha512-SgpgScL4T7Hj/w/GexjnBHi3Ien9WS1Rpfg5y91WXMj9SY997ZCQU76mH4TpLwwfmMvoOU8wiaRkIf6NaH3mtg==",
       "optional": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justia/ga-releaser",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A script to generate releases and changelog",
   "scripts": {},
   "repository": {
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/justia/ga-releaser#readme",
   "dependencies": {
-    "@justia/releaser": "^1.2.0"
+    "@justia/releaser": "^1.3.2"
   }
 }


### PR DESCRIPTION
## General

### Features

- Update @justia/releaser package with all improvements (11dcb209fe165f570a439ebccce12a5b03ba2efc)
  - Reference: https://github.com/justia/front-end-projects/pull/187

### Documentation

- Update readme.md (1af6a7e00a3858162d5c66dbb380003cadf609e5)

### Code Refactoring

- Add releaser_bypass_pr_token environment variable (50cc4832469782e3b7d0dd85e0a71bbf7dcf56c9)
- Change mm to minor on calver default (7125edb73adb71970df3ee39072f1863e0b35057)


## release

### Chore

- 1.3.0 (c453a4a062ed497db0fbc4d2046c3426ff6b3436)


